### PR TITLE
Fix/aum

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -57,7 +57,7 @@ const createErrorLink = () =>
 
 const createDataLink = () => {
   const httpLink = new HttpLink({
-    uri: 'https://api.thegraph.com/subgraphs/name/melonproject/melon',
+    uri: 'https://api.thegraph.com/subgraphs/id/QmTcFd9qtqrhdJk5ezK72HUnYAqemepMwr5p7XyGmUZAt9',
   });
 
   if (!process.browser) {
@@ -65,7 +65,7 @@ const createDataLink = () => {
   }
 
   const wsLink = new WebSocketLink({
-    uri: 'wss://api.thegraph.com/subgraphs/name/melonproject/melon',
+    uri: 'wss://api.thegraph.com/subgraphs/id/QmTcFd9qtqrhdJk5ezK72HUnYAqemepMwr5p7XyGmUZAt9',
     options: {
       reconnect: true,
     },

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -57,7 +57,7 @@ const createErrorLink = () =>
 
 const createDataLink = () => {
   const httpLink = new HttpLink({
-    uri: 'https://api.thegraph.com/subgraphs/id/QmTcFd9qtqrhdJk5ezK72HUnYAqemepMwr5p7XyGmUZAt9',
+    uri: 'https://api.thegraph.com/subgraphs/name/melonproject/melon',
   });
 
   if (!process.browser) {
@@ -65,7 +65,7 @@ const createDataLink = () => {
   }
 
   const wsLink = new WebSocketLink({
-    uri: 'wss://api.thegraph.com/subgraphs/id/QmTcFd9qtqrhdJk5ezK72HUnYAqemepMwr5p7XyGmUZAt9',
+    uri: 'wss://api.thegraph.com/subgraphs/name/melonproject/melon',
     options: {
       reconnect: true,
     },

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -137,7 +137,7 @@ const Network: React.FunctionComponent<NetworkProps> = props => {
   );
 
   const melonNetworkHistories = R.pathOr([], ['data', 'melonNetworkHistories'], historyResult)
-    .filter(item => item.validGav)
+    // .filter(item => item.validGav)
     .map(item => {
       return {
         ...item,

--- a/pages/investor.tsx
+++ b/pages/investor.tsx
@@ -50,6 +50,7 @@ const Investor: React.FunctionComponent<InvestorProps> = props => {
     proceedPaths(['investmentValuationHistories']),
     {
       ssr: false,
+      skip: !(router && router.query.address),
       variables: {
         ids: investmentList.map(investment => investment.id),
       },
@@ -96,6 +97,7 @@ const Investor: React.FunctionComponent<InvestorProps> = props => {
     proceedPaths(['investorValuationHistories']),
     {
       ssr: false,
+      skip: !(router && router.query.address),
       variables: {
         id: router && router.query.address,
       },


### PR DESCRIPTION
Fixes AUM numbers on main page.

Previously, whenever an asset had an invalid price, all funds that that were allowed to invest into this asset were regarded as having an invalid price and the total AUM of the network was labelled as "notValid" and not shown.

Now, only funds that actually own a non-zero amount of the asset with invalid price are deemed to have an invalid price. They are excluded from the total AUM of the network, but the total AUM number is still shown.  This sometimes leads to sharp negative spikes in the graph.